### PR TITLE
Move time zone conversion

### DIFF
--- a/src/components/GamesList.vue
+++ b/src/components/GamesList.vue
@@ -1,19 +1,14 @@
 <script setup>
-import { ref, computed, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import { parseJSON } from "date-fns";
-import { $selectedTeams, $teamsList, $teamIds, $hasTeams } from "../stores/teamStore";
+import { computed, ref, watch } from "vue";
+import { $hasTeams, $teamIds } from "../stores/teamStore";
 import GameCard from "./GameCard.vue";
 
 const props = defineProps({
   range: String,
-  reverseOrder: {
-    type: Boolean,
-    default: false
-  }
+  reverseOrder: Boolean
 });
-const selectedTeams = useStore($selectedTeams);
-const teamsList = useStore($teamsList);
 const teamIds = useStore($teamIds);
 const hasTeams = useStore($hasTeams);
 const gamesList = ref({ games: [] });

--- a/src/pages/api/getSchedule.ts
+++ b/src/pages/api/getSchedule.ts
@@ -1,6 +1,5 @@
 import type { APIRoute } from "astro";
 import { BASE_URL, MOCK_URL } from "astro:env/server";
-import { parseJSON } from "date-fns";
 
 type DateRange = "today" | "next7" | "prev7" | "upcoming" | "previous";
 type Status = "Final" | "Preview" | "Scheduled" | "Live";
@@ -35,8 +34,7 @@ interface ScheduleData {
 }
 
 interface TransformedGame {
-  date: string;
-  time: string;
+  dateTime: string;
   awayTeam: string;
   homeTeam: string;
   gameStatus: Status;
@@ -140,12 +138,8 @@ export const GET: APIRoute = async ({ url }): Promise<Response> => {
       const totalGames: TransformedGame[] = [];
 
       gameDate.games.forEach((game: Game) => {
-        // Convert date and time from UTC to local time
-        const { localDate, localTime } = convertToLocalDateTime(game.gameDate);
-
         const currentGame = {
-          date: localDate,
-          time: localTime,
+          dateTime: game.gameDate,
           awayTeam: teamsMap.get(game.teams.away.team.id) || "",
           homeTeam: teamsMap.get(game.teams.home.team.id) || "",
           gameStatus: game.status.abstractGameState,
@@ -195,27 +189,4 @@ export const GET: APIRoute = async ({ url }): Promise<Response> => {
 // Helper function to format date as YYYY-MM-DD
 function formatDate(date: Date): string {
   return date.toISOString().split("T")[0];
-}
-
-// Helper function to convert UTC date and time to local date and time
-function convertToLocalDateTime(dateTimeStr: string): {
-  localDate: string;
-  localTime: string;
-} {
-  const dateObject = parseJSON(dateTimeStr);
-  const localDateStr = dateObject.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-  const localTimeStr = dateObject.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-
-  return {
-    localDate: localDateStr,
-    localTime: localTimeStr,
-  };
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <GamesList client:only="vue" range="next7" />
   <a href="/future-games">See all upcoming games</a>
   <h2>Previous Games</h2>
-  <GamesList client:only="vue" range="prev7" reverseOrder={true} />
+  <GamesList client:only="vue" range="prev7" reverseOrder />
   <a href="/past-games">See all past games</a>
 </BaseLayout>
 


### PR DESCRIPTION
Noticed time zones weren't showing the expected times because the conversion was done on the server, which is likely in a different time zone than the user. So moved the conversion to the client side so it will show expected times.